### PR TITLE
Expose an ability to set the booru filter

### DIFF
--- a/derpibooru/helpers.py
+++ b/derpibooru/helpers.py
@@ -70,6 +70,8 @@ def format_params(params):
         p[key] = value
     elif key == "q":
       p["q"] = ",".join(value) if value else "*"
+    elif key in ("session", "filter"):
+      continue
     else:
       p[key] = value
 

--- a/derpibooru/image.py
+++ b/derpibooru/image.py
@@ -38,7 +38,8 @@ class Image(object):
   its own property. Once instantiated the data is immutable so as to reflect
   the stateless nature of a REST API
   """
-  def __init__(self, data):
+  def __init__(self, session, data):
+    self._session = session
     self._data = data
 
     for field, body in data.items():
@@ -133,7 +134,7 @@ class Image(object):
     return self._data
 
   def update(self):
-    data = get_image_data(self.id_number)
+    data = get_image_data(self._session, self.id_number)
 
     if data:
       self._data = data

--- a/derpibooru/request.py
+++ b/derpibooru/request.py
@@ -105,7 +105,7 @@ def set_site_filter(session, filter_id):
   if spoofrequest.status_code == codes.ok:
     csrfnameregex = '<meta name="csrf-param" content="(.+?)"\/>'  # I know, regex and HTML
     csrfregex = '<meta name="csrf-token" content="(.+?)"\/>'  # I am the devil reincarnate
-    spoofdata[re.match(csrfnameregex, spoofrequest.text).group(0)] = re.match(csrfregex, spoofrequest.text).group(0)
+    spoofdata[re.search(csrfnameregex, spoofrequest.text).group(1)] = re.search(csrfregex, spoofrequest.text).group(1)
   else:
     return False
   url = "https://derpibooru.org/filters/select?id={}".format(filter_id)

--- a/derpibooru/search.py
+++ b/derpibooru/search.py
@@ -25,7 +25,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from sys import version_info
-
+from requests import Session
 from .request import get_images, url
 from .image import Image
 from .helpers import tags, api_key, sort_format, join_params, user_option, set_limit
@@ -43,13 +43,15 @@ class Search(object):
   interactions predictable as well as making versioning of searches relatively
   easy.
   """
-  def __init__(self, key="", q={}, sf="created_at", sd="desc", limit=50,
+  def __init__(self, session=Session(), filter=None, key="", q={}, sf="created_at", sd="desc", limit=50,
                faves="", upvotes="", uploads="", watched=""):
     """
     By default initializes an instance of Search with the parameters to get
     the first 50 images on Derpibooru's front page.
     """
     self._params = {
+      "session": session,
+      "filter": filter,
       "key": api_key(key),
       "q": tags(q),
       "sf": sort_format(sf),
@@ -176,12 +178,20 @@ class Search(object):
 
     return self.__class__(**params)
 
+  def filter(self, id):
+    """
+    Set the filter to use by ID.
+    """
+    params = join_params(self.parameters, {"filter": id})
+
+    return self.__class__(**params)
+
 if version_info < (3, 0):
   def next(self):
     """
     Returns a result wrapped in a new instance of Image().
     """
-    return Image(self._search.next())
+    return Image(self._params["session"], self._search.next())
 
   Search.next = next
 
@@ -190,7 +200,7 @@ else:
     """
     Returns a result wrapped in a new instance of Image().
     """
-    return Image(next(self._search))
+    return Image(self._params["session"], next(self._search))
 
   Search.__next__ = __next__
 


### PR DESCRIPTION
Requires a session to store cookies, which happens to also increase
speeds by reusing the connection.

Not gonna lie, it's pretty ugly. I pretty much shoe-horned in the session with everything else, and then there's the fact that there isn't an API for setting the filter yet.
I've fired off an email to Clover about an API for it, but this works in the mean time, it just needs to do an extra request to get the CSRF token.