### PR TITLE
Fix exception when loading certain GIFs

### DIFF
--- a/derpibooru/image.py
+++ b/derpibooru/image.py
@@ -46,8 +46,10 @@ class Image(object):
         setattr(self, field, body) 
 
     if self.original_format == "gif":
-      setattr(self, "webm", self.representations["webm"])
-      setattr(self, "mp4", self.representations["mp4"])
+      if "webm" in self.representations.keys():
+        setattr(self, "webm", self.representations["webm"])
+      if "mp4" in self.representations.keys():
+        setattr(self, "mp4", self.representations["mp4"])
 
 
   def __str__(self):


### PR DESCRIPTION
WebM and MP4 isn't always available, so first check if they are.
