### PR TITLE
Removing faulty import

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,6 @@
 from setuptools import setup
 from setuptools import find_packages
 
-import derpibooru
-
 setup(
   name = "DerPyBooru",
   description = "Python bindings for Derpibooru's API",


### PR DESCRIPTION
As pointed out in #14, the import in this is breaking pip because it tries to import requests before it's installed. As far as I can see, this import doesn't do anything, and it installed fine without it. So I request that this line gets removed so this package gets installed correctly through pip.